### PR TITLE
Change plain text link to markdown link

### DIFF
--- a/content/code-style/javascript.md
+++ b/content/code-style/javascript.md
@@ -17,7 +17,7 @@
 
 This guide should be used side by side with our base ESLint configuration file, which has its own repository and is available on npm.
 
-https://github.com/spatie/eslint-config-spatie
+[https://github.com/spatie/eslint-config-spatie](https://github.com/spatie/eslint-config-spatie)
 
 ```
 yarn add --dev eslint-config-spatie


### PR DESCRIPTION
Github automatically makes links clickable in its markdown parser but the static site doesn't: https://guidelines.spatie.be/code-style/javascript. This pull-requests makes the link explicit using markdown.