### PR TITLE
Fix double closing curly brackets in happy path

### DIFF
--- a/content/code-style/laravel-php.md
+++ b/content/code-style/laravel-php.md
@@ -210,7 +210,7 @@ Generally a function should have its unhappy path first and its happy path last.
 
 if (! $goodCondition) {
   throw new Exception;
-}}
+}
 
 // do work
 ```
@@ -221,7 +221,7 @@ if (! $goodCondition) {
 
 if ($goodCondition) {
  // do work
-}}
+}
 
 throw new Exception;
 ```


### PR DESCRIPTION
There should be one bracket for each of `if` statements in [happy path](https://guidelines.spatie.be/code-style/laravel-php#happy-path) instead of two.